### PR TITLE
fix: semgrep-insecure-document-method

### DIFF
--- a/app.js
+++ b/app.js
@@ -176,14 +176,24 @@ function updateScansUI() {
   appState.scans.items.forEach(scan => {
     const row = document.createElement('div');
     row.className = 'scan-row';
-    row.innerHTML = `
-      <div class="table-cell">${scan.target || 'Untitled Scan'}</div>
-      <div class="table-cell">${(scan.scan_type || 'UNKNOWN').toUpperCase()}</div>
-      <div class="table-cell">${scan.status || 'PENDING'}</div>
-      <div class="table-cell">-</div>
-      <div class="table-cell">${scan.created_at ? new Date(scan.created_at).toLocaleString() : 'Date not available'}</div>
-      <div class="table-cell">-</div>
-    `;
+
+    // Safely create and append each cell using DOM methods instead of innerHTML
+    const cells = [
+      { text: scan.target || 'Untitled Scan' },
+      { text: (scan.scan_type || 'UNKNOWN').toUpperCase() },
+      { text: scan.status || 'PENDING' },
+      { text: '-' },
+      { text: scan.created_at ? new Date(scan.created_at).toLocaleString() : 'Date not available' },
+      { text: '-' }
+    ];
+
+    cells.forEach(cellData => {
+      const cell = document.createElement('div');
+      cell.className = 'table-cell';
+      cell.textContent = cellData.text; // Using textContent properly escapes the content
+      row.appendChild(cell);
+    });
+
     scansTableBody.appendChild(row);
   });
   
@@ -221,14 +231,24 @@ function updateVulnerabilitiesUI() {
   appState.vulnerabilities.items.forEach(vuln => {
     const row = document.createElement('div');
     row.className = 'scan-row';
-    row.innerHTML = `
-      <div class="table-cell">${vuln.title || '-'}</div>
-      <div class="table-cell">${vuln.severity || '-'}</div>
-      <div class="table-cell">${vuln.cve_id || '-'}</div>
-      <div class="table-cell">${vuln.affected_package || '-'}</div>
-      <div class="table-cell">${vuln.fix_version || '-'}</div>
-      <div class="table-cell">${vuln.created_at ? new Date(vuln.created_at).toLocaleString() : '-'}</div>
-    `;
+
+    // Safely create and append each cell using DOM methods instead of innerHTML
+    const cells = [
+      { text: vuln.title || '-' },
+      { text: vuln.severity || '-' },
+      { text: vuln.cve_id || '-' },
+      { text: vuln.affected_package || '-' },
+      { text: vuln.fix_version || '-' },
+      { text: vuln.created_at ? new Date(vuln.created_at).toLocaleString() : '-' }
+    ];
+
+    cells.forEach(cellData => {
+      const cell = document.createElement('div');
+      cell.className = 'table-cell';
+      cell.textContent = cellData.text; // Using textContent properly escapes the content
+      row.appendChild(cell);
+    });
+
     vulnTableBody.appendChild(row);
   });
   


### PR DESCRIPTION
### Pull Request — Semgrep Rule Fix

- Rule ID: insecure-document-method
- Rule Message: User controlled data in methods like `innerHTML`, `outerHTML` or `document.write` is an anti-pattern that can lead to XSS vulnerabilities
- File Path: /tools/scanResult/unzipped-2651363906/app.js
- Line: 179


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened rendering of scan and vulnerability tables to prevent HTML injection by safely escaping content. No visible UI changes.

* **Refactor**
  * Adopted explicit DOM-based cell creation for table rows to improve safety and maintainability without altering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->